### PR TITLE
Add helpers to override CSS and widget URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,26 @@ janrain.events.onCaptureRegistrationSuccess.addHandler(function(result) {
 });
 ```
 
+#### Overriding URLs for the login widget and CSS
+
+To provide your own values for the Janrain login widget or associated
+CSS, set them in `config/initializers/devise.rb`:
+
+```ruby
+Devise.setup do |config|
+  # Other configuration ...
+  config.janrain_widget_url = '//mydomain.com/path/to/widget.js'
+  config.janrain_css_url = '//mydomain.com/path/to/style.css'
+  config.janrain_mobile_css_url = '//mydomain.com/path/to/style.css'
+end
+```
+
+`janrain_css_url` and `janrain_mobile_css_url` can accept multiple URLs;
+just separate them by a space within the same string. (For example,
+`'//mydomain.com/style1.css //mydomain.com/style2.css`). This makes it
+easy to set these as environment variables, then load them in your
+Devise initializer.
+
 ## Running the Tests
 
 * Install development and test dependencies with `bundle install`

--- a/app/helpers/capturable_helper.rb
+++ b/app/helpers/capturable_helper.rb
@@ -9,4 +9,25 @@ module CapturableHelper
   def devise_resource_name
     Devise.mappings.keys[0].to_s
   end
+
+  def janrain_css_url
+    if Devise.janrain_css_url
+      Devise.janrain_css_url.split(' ').to_json
+    else
+      ['//cdn.oreillystatic.com/members/css/janrain.min.css'].to_json
+    end
+  end
+
+  def janrain_mobile_css_url
+    if Devise.janrain_mobile_css_url
+      Devise.janrain_mobile_css_url.split(' ').to_json
+    else
+      ['//cdn.oreillystatic.com/members/css/janrain-mobile.min.css'].to_json
+    end
+  end
+
+  def janrain_widget_url
+    Devise.janrain_widget_url ||
+      '//cdn.oreillystatic.com/members/js/widgets/login-widget.min.js'
+  end
 end

--- a/app/views/capturable/_widget.html.erb
+++ b/app/views/capturable/_widget.html.erb
@@ -38,8 +38,7 @@
   <style>
     #janrainCaptureWidget { display: none; }
   </style>
-  <script src="//cdn.oreillystatic.com/members/js/widgets/login-widget.min.js"
-          id="janrainCaptureScript">
+  <script src="<%= janrain_widget_url %>" id="janrainCaptureScript">
   </script>
   <a href="#" id="capture_signin_link" class="signInLink capture_modal_open">Sign In/Sign Up</a>
 <% end %>
@@ -59,8 +58,7 @@
   <style>
     #janrainCaptureWidget { display: none; }
   </style>
-  <script src="//cdn.oreillystatic.com/members/js/widgets/login-widget.min.js"
-          id="janrainCaptureScript">
+  <script src="<%= janrain_widget_url %>" id="janrainCaptureScript">
   </script>
   <a href="#" class="signOutLink capture_end_session">Sign Out</a>
 <% end %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -32,5 +32,5 @@
 </script>
 <%= render 'capturable/noscript' %>
 
-<script src="//cdn.oreillystatic.com/members/js/widgets/login-widget.min.js" id="janrainCaptureScript"></script>
+<script src="<%= janrain_widget_url %>" id="janrainCaptureScript"></script>
 </div>

--- a/lib/devise_capturable.rb
+++ b/lib/devise_capturable.rb
@@ -13,6 +13,9 @@ module Devise
   mattr_accessor :capturable_redirect_uri
   mattr_accessor :capturable_auto_create_account
   mattr_accessor :capturable_redirect_if_no_user
+  mattr_accessor :janrain_css_url
+  mattr_accessor :janrain_mobile_css_url
+  mattr_accessor :janrain_widget_url
 end
 
 Devise.capturable_auto_create_account = true

--- a/spec/helpers/capturable_helper_spec.rb
+++ b/spec/helpers/capturable_helper_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+describe CapturableHelper, type: :helper do
+  describe 'janrain_css_url' do
+    context 'when not overridden' do
+      it 'returns a default URL' do
+        expect(helper.janrain_css_url).to eq \
+          '["//cdn.oreillystatic.com/members/css/janrain.min.css"]'
+      end
+    end
+
+    context 'when overridden' do
+      it 'returns the overriding URL' do
+        Devise.janrain_css_url = '//example.com/sample.css'
+        expect(helper.janrain_css_url).to eq \
+          '["//example.com/sample.css"]'
+      end
+
+      it 'accepts multiple URLs, delimited by spaces' do
+        Devise.janrain_css_url = \
+          '//example.com/one.css //example.com/two.css'
+        expect(helper.janrain_css_url).to eq \
+          '["//example.com/one.css","//example.com/two.css"]'
+      end
+    end
+  end
+
+  describe 'janrain_mobile_css_url' do
+    context 'when not overridden' do
+      it 'returns a default URL' do
+        expect(helper.janrain_mobile_css_url).to eq \
+          '["//cdn.oreillystatic.com/members/css/janrain-mobile.min.css"]'
+      end
+    end
+
+    context 'when overridden' do
+      it 'returns the overriding URL' do
+        Devise.janrain_mobile_css_url = '//example.com/sample.css'
+        expect(helper.janrain_mobile_css_url).to eq \
+          '["//example.com/sample.css"]'
+      end
+
+      it 'accepts multiple URLs, delimited by spaces' do
+        Devise.janrain_mobile_css_url = \
+          '//example.com/one.css //example.com/two.css'
+        expect(helper.janrain_mobile_css_url).to eq \
+          '["//example.com/one.css","//example.com/two.css"]'
+      end
+    end
+  end
+
+  describe 'janrain_widget_url' do
+    context 'when not overridden' do
+      it 'returns a default URL' do
+        expect(helper.janrain_widget_url).to eq \
+          '//cdn.oreillystatic.com/members/js/widgets/login-widget.min.js'
+      end
+    end
+
+    context 'when overridden' do
+      it 'returns the overriding URL' do
+        Devise.janrain_widget_url = '//example.com/widget.js'
+        expect(helper.janrain_widget_url).to eq '//example.com/widget.js'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Since this is a little more involved than other work that's been done in the capturable-extended branch, I'd appreciate another set of eyes. This would allow a developer using Capturable to override the location of Janrain CSS or JS files that we host on the CDN, primarily for the purpose of testing changes to these files before putting them into production. I did some local testing against the customer support portal, and will push changes to that repo separately. (Sorry for earlier edits to this comment; I missed some changes I made.)

Thanks,
Aaron

---

Values for CSS and the widget JavaScript are hard-coded into
Devise::Capturable. This does not allow apps using the library to
behave like proper 12-factor applications, particularly if
developers want to test changes to these files in staging environments.

Add support for overriding these values by adding helpers to
Devise::Capturable. If new values aren't set, use the existing URLs
that are already in place. Add documentation to the README to explain
how to customize these settings.

https://oreillymedia.atlassian.net/browse/ACONF-2469
