### PR TITLE
Handle more onCaptureLoginSuccess and onCaptureRegistrationSuccess callbacks

### DIFF
--- a/app/views/capturable/_widget.html.erb
+++ b/app/views/capturable/_widget.html.erb
@@ -9,14 +9,22 @@
     janrain.capture.ui.start();
 
     janrain.events.onCaptureLoginSuccess.addHandler(function(result) {
-      janrain.capture.ui.modal.close();
-      $('#login').html($('#loading').html());
-      sendAuthorizationCodeToServer(result.authorizationCode, 'skip');
+      if (result.authorizationCode){
+        janrain.capture.ui.modal.close();
+        $('#login').html($('#loading').html());
+        sendAuthorizationCodeToServer(result.authorizationCode, 'skip');
+      }else if (result.accessToken){
+        janrain.capture.ui.createCaptureSession(result.accessToken);
+      }
     });
     janrain.events.onCaptureRegistrationSuccess.addHandler(function(result) {
-      janrain.capture.ui.modal.close();
-      $('#login').html($('#loading').html());
-      sendAuthorizationCodeToServer(result.authorizationCode, 'skip');
+      if(result.authorizationCode){
+        janrain.capture.ui.modal.close();
+        $('#login').html($('#loading').html());
+        sendAuthorizationCodeToServer(result.authorizationCode, 'skip');
+      }else if(result.accessToken){
+        janrain.capture.ui.createCaptureSession(result.accessToken);
+      }
     });
     janrain.events.onCaptureScreenShow.addHandler(function(result) {
       if (result.screen == 'returnTraditional') {


### PR DESCRIPTION
Both onCaptureLoginSuccess and onCaptureRegistrationSuccess can be registered
to get called back with codes rather than access tokens but for some federate edge
cases (federate login occurs while local session exists being one), the callback
instead contains an accessToken which can be used to better sync session status
between federate apps.
